### PR TITLE
메인 페이지 인기앨범차트 디자인

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "semi": true,
   "useTabs": false,
   "tabWidth": 2,
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }

--- a/src/components/AlbumChart.tsx
+++ b/src/components/AlbumChart.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Box, Typography, Button, Container, Card, CardMedia, CardContent, Rating } from '@mui/material';
+// import { useTheme } from '@mui/material/styles';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import StarIcon from '@mui/icons-material/Star';
@@ -9,6 +10,8 @@ import { AlbumCharts } from '../types/albumChart';
 import BASE_URL from '../config';
 
 function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: number) {
+  // const theme = useTheme();
+
   return (
     <Box
       sx={{
@@ -19,7 +22,7 @@ function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: numbe
     >
       {Array.isArray(data?.top5Albums) ? (
         data?.top5Albums.slice(startIndex, endIndex).map((item, index) => (
-          <Link to={`${item.albumId}`} key={item.albumId} style={{ textDecorationLine: 'none' }}>
+          <Link to={`/album/${item.albumId}`} key={item.albumId} style={{ textDecorationLine: 'none' }}>
             <Card
               sx={{
                 bgcolor: 'background.default',
@@ -54,10 +57,10 @@ function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: numbe
                 }}
               />
               <CardContent sx={{ marginTop: '8px' }}>
-                <Typography align="left" sx={{ fontSize: '14px' }}>
+                <Typography align="left" fontSize="fontSizeMd">
                   {item.albumTitle.split('-', 2)[1]}
                 </Typography>
-                <Typography align="left" sx={{ fontSize: '11px', marginTop: '4px', marginBottom: '4px' }}>
+                <Typography align="left" fontSize="fontSizeXs" sx={{ marginTop: '4px', marginBottom: '4px' }}>
                   {item.albumTitle.split('-', 2)[0]}
                 </Typography>
                 <Box sx={{ display: 'flex' }}>
@@ -72,7 +75,7 @@ function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: numbe
                           marginBottom: '0.5px',
                           width: '15px',
                           height: '15px',
-                          color: '#FFC403',
+                          color: 'star.main',
                         }}
                       />
                     }
@@ -83,14 +86,14 @@ function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: numbe
                           marginBottom: '0.5px',
                           width: '15px',
                           height: '15px',
-                          color: '#FFC403',
+                          color: 'star.main',
                         }}
                       />
                     }
                     sx={{ marginRight: '4px' }}
                     readOnly
                   />
-                  <Typography sx={{ fontSize: '11px' }}>{item.averageRating.toFixed(1)}</Typography>
+                  <Typography fontSize="fontSizeXs">{item.averageRating.toFixed(1)}</Typography>
                 </Box>
               </CardContent>
             </Card>

--- a/src/components/AlbumChart.tsx
+++ b/src/components/AlbumChart.tsx
@@ -1,31 +1,12 @@
 import { Link } from 'react-router-dom';
-import {
-  Box,
-  Typography,
-  Button,
-  Container,
-  Card,
-  CardMedia,
-  CardContent,
-  LinearProgress,
-  styled,
-  LinearProgressProps,
-} from '@mui/material';
+import { Box, Typography, Button, Container, Card, CardMedia, CardContent, Rating } from '@mui/material';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { useState, useEffect } from 'react';
 import { AlbumCharts } from '../types/albumChart';
 import BASE_URL from '../config';
-
-const StarRatingBar = styled(LinearProgress)<LinearProgressProps>(({ theme }) => ({
-  height: '10px',
-  width: '60px',
-  backgroundColor: 'yellow',
-
-  '& .MuiLinearProgress-barColorPrimary': {
-    backgroundColor: `${theme.palette.grey}`,
-  },
-}));
 
 function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: number) {
   return (
@@ -38,12 +19,12 @@ function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: numbe
     >
       {Array.isArray(data?.top5Albums) ? (
         data?.top5Albums.slice(startIndex, endIndex).map((item, index) => (
-          <Link to={`${item.albumId}`} key={item.albumId}>
+          <Link to={`${item.albumId}`} key={item.albumId} style={{ textDecorationLine: 'none' }}>
             <Card
               sx={{
                 bgcolor: 'background.default',
                 // width: '288px',
-                // height: '60px',
+                height: '60px',
                 display: 'flex',
                 flexDirection: 'row',
                 justifyContent: 'flex-start',
@@ -56,7 +37,7 @@ function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: numbe
                 boxShadow: 'none',
               }}
             >
-              <CardContent sx={{ margin: '0px 12px' }}>
+              <CardContent sx={{ marginLeft: '12px' }}>
                 <Typography>{index + startIndex + 1}</Typography>
               </CardContent>
               <CardMedia
@@ -72,14 +53,44 @@ function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: numbe
                   margin: '0px 20px',
                 }}
               />
-              <CardContent>
-                <Typography align="left">{item.albumTitle.split('-', 2)[1]}</Typography>
-                <Typography variant="body2" align="left">
+              <CardContent sx={{ marginTop: '8px' }}>
+                <Typography align="left" sx={{ fontSize: '14px' }}>
+                  {item.albumTitle.split('-', 2)[1]}
+                </Typography>
+                <Typography align="left" sx={{ fontSize: '11px', marginTop: '4px', marginBottom: '4px' }}>
                   {item.albumTitle.split('-', 2)[0]}
                 </Typography>
                 <Box sx={{ display: 'flex' }}>
-                  <StarRatingBar variant="determinate" value={item.averageRating * 20} />
-                  <Typography>{item.averageRating.toFixed(1)}</Typography>
+                  <Rating
+                    name="half-rating-read"
+                    value={item.averageRating}
+                    precision={0.1}
+                    icon={
+                      <StarIcon
+                        sx={{
+                          marginTop: '0.5px',
+                          marginBottom: '0.5px',
+                          width: '15px',
+                          height: '15px',
+                          color: '#FFC403',
+                        }}
+                      />
+                    }
+                    emptyIcon={
+                      <StarBorderIcon
+                        sx={{
+                          marginTop: '0.5px',
+                          marginBottom: '0.5px',
+                          width: '15px',
+                          height: '15px',
+                          color: '#FFC403',
+                        }}
+                      />
+                    }
+                    sx={{ marginRight: '4px' }}
+                    readOnly
+                  />
+                  <Typography sx={{ fontSize: '11px' }}>{item.averageRating.toFixed(1)}</Typography>
                 </Box>
               </CardContent>
             </Card>
@@ -114,7 +125,7 @@ function AlbumChart() {
   return (
     <Container maxWidth="md" sx={{ marginTop: '75px' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Typography variant="h1">인기 앨범 TOP20</Typography>
+        <Typography variant="h1">인기 앨범 차트</Typography>
         <Box sx={{ display: 'flex' }}>
           <Button
             variant="outlined"
@@ -148,40 +159,6 @@ function AlbumChart() {
         {AlbumList(data, 4, 8)}
       </Box>
     </Container>
-
-    // <div className="album-chart">
-    //   <h1>앨범 차트</h1>
-
-    //   <a href="/album?sort=alltime">All Time</a>
-    //   <a href="/album?sort=yearly">1 year</a>
-
-    //   <div className="title">
-    //     <h1>인기 리뷰 앨범</h1>
-    //     <p>
-    //       하입합 유저들의 평가를 반영한 차트입니다.
-    //       <br />
-    //       앨범의 평균 평점과 평가 수를 반영합니다.
-    //     </p>
-    //   </div>
-
-    //   {Array.isArray(data?.top5Albums) ? (
-    //     data?.top5Albums.map((item) => (
-    //       <Link to={`${item.albumId}`} key={item.albumId}>
-    //         <div className="box">
-    //           <div className="cover">
-    //             <img src={item.thumbnail} alt="cover" />
-    //           </div>
-
-    //           <div className="name">
-    //             <span>{item.averageRating}</span> {item.albumTitle}
-    //           </div>
-    //         </div>
-    //       </Link>
-    //     ))
-    //   ) : (
-    //     <p>Empty</p>
-    //   )}
-    // </div>
   );
 }
 

--- a/src/components/AlbumChart.tsx
+++ b/src/components/AlbumChart.tsx
@@ -1,7 +1,96 @@
 import { Link } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  Button,
+  Container,
+  Card,
+  CardMedia,
+  CardContent,
+  LinearProgress,
+  styled,
+  LinearProgressProps,
+} from '@mui/material';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import { useState, useEffect } from 'react';
 import { AlbumCharts } from '../types/albumChart';
 import BASE_URL from '../config';
+
+const StarRatingBar = styled(LinearProgress)<LinearProgressProps>(({ theme }) => ({
+  height: '10px',
+  width: '60px',
+  backgroundColor: 'yellow',
+
+  '& .MuiLinearProgress-barColorPrimary': {
+    backgroundColor: `${theme.palette.grey}`,
+  },
+}));
+
+function AlbumList(data: AlbumCharts | null, startIndex: number, endIndex: number) {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        marginTop: '16px',
+        gridTemplateRows: 'repeat(4, 1fr)',
+      }}
+    >
+      {Array.isArray(data?.top5Albums) ? (
+        data?.top5Albums.slice(startIndex, endIndex).map((item, index) => (
+          <Link to={`${item.albumId}`} key={item.albumId}>
+            <Card
+              sx={{
+                bgcolor: 'background.default',
+                // width: '288px',
+                // height: '60px',
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'flex-start',
+                alignItems: 'center',
+                padding: '0px',
+                flex: 'none',
+                order: '0',
+                flexGrow: '0',
+                margin: '16px 0px',
+                boxShadow: 'none',
+              }}
+            >
+              <CardContent sx={{ margin: '0px 12px' }}>
+                <Typography>{index + startIndex + 1}</Typography>
+              </CardContent>
+              <CardMedia
+                component="img"
+                width="60px"
+                height="60px"
+                image={item.thumbnail}
+                alt="album cover"
+                sx={{
+                  maxWidth: '60px',
+                  minWidth: '60px',
+                  borderRadius: '6.6px',
+                  margin: '0px 20px',
+                }}
+              />
+              <CardContent>
+                <Typography align="left">{item.albumTitle.split('-', 2)[1]}</Typography>
+                <Typography variant="body2" align="left">
+                  {item.albumTitle.split('-', 2)[0]}
+                </Typography>
+                <Box sx={{ display: 'flex' }}>
+                  <StarRatingBar variant="determinate" value={item.averageRating * 20} />
+                  <Typography>{item.averageRating.toFixed(1)}</Typography>
+                </Box>
+              </CardContent>
+            </Card>
+          </Link>
+        ))
+      ) : (
+        <Typography>List Empty</Typography>
+      )}
+    </Box>
+  );
+}
 
 function AlbumChart() {
   const [data, setData] = useState<AlbumCharts | null>(null);
@@ -23,39 +112,76 @@ function AlbumChart() {
   }, []);
 
   return (
-    <div className="album-chart">
-      <h1>앨범 차트</h1>
+    <Container maxWidth="md" sx={{ marginTop: '75px' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography variant="h1">인기 앨범 TOP20</Typography>
+        <Box sx={{ display: 'flex' }}>
+          <Button
+            variant="outlined"
+            sx={{
+              margin: '7px',
+              maxHeight: 36,
+              maxWidth: 36,
+              minHeight: 36,
+              minWidth: 36,
+            }}
+          >
+            <ArrowBackIosNewIcon fontSize="small" />
+          </Button>
+          <Button
+            variant="outlined"
+            sx={{
+              margin: '7px',
+              maxHeight: 36,
+              maxWidth: 36,
+              minHeight: 36,
+              minWidth: 36,
+            }}
+          >
+            <ArrowForwardIosIcon fontSize="small" />
+          </Button>
+        </Box>
+      </Box>
 
-      <a href="/album?sort=alltime">All Time</a>
-      <a href="/album?sort=yearly">1 year</a>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, 2fr)' }}>
+        {AlbumList(data, 0, 4)}
+        {AlbumList(data, 4, 8)}
+      </Box>
+    </Container>
 
-      <div className="title">
-        <h1>인기 리뷰 앨범</h1>
-        <p>
-          하입합 유저들의 평가를 반영한 차트입니다.
-          <br />
-          앨범의 평균 평점과 평가 수를 반영합니다.
-        </p>
-      </div>
+    // <div className="album-chart">
+    //   <h1>앨범 차트</h1>
 
-      {Array.isArray(data?.top5Albums) ? (
-        data?.top5Albums.map((item) => (
-          <Link to={`${item.albumId}`} key={item.albumId}>
-            <div className="box">
-              <div className="cover">
-                <img src={item.thumbnail} alt="cover" />
-              </div>
+    //   <a href="/album?sort=alltime">All Time</a>
+    //   <a href="/album?sort=yearly">1 year</a>
 
-              <div className="name">
-                <span>{item.averageRating}</span> {item.albumTitle}
-              </div>
-            </div>
-          </Link>
-        ))
-      ) : (
-        <p>Empty</p>
-      )}
-    </div>
+    //   <div className="title">
+    //     <h1>인기 리뷰 앨범</h1>
+    //     <p>
+    //       하입합 유저들의 평가를 반영한 차트입니다.
+    //       <br />
+    //       앨범의 평균 평점과 평가 수를 반영합니다.
+    //     </p>
+    //   </div>
+
+    //   {Array.isArray(data?.top5Albums) ? (
+    //     data?.top5Albums.map((item) => (
+    //       <Link to={`${item.albumId}`} key={item.albumId}>
+    //         <div className="box">
+    //           <div className="cover">
+    //             <img src={item.thumbnail} alt="cover" />
+    //           </div>
+
+    //           <div className="name">
+    //             <span>{item.averageRating}</span> {item.albumTitle}
+    //           </div>
+    //         </div>
+    //       </Link>
+    //     ))
+    //   ) : (
+    //     <p>Empty</p>
+    //   )}
+    // </div>
   );
 }
 

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -43,6 +43,9 @@ const theme = createTheme({
       light: 'rgb(215,215,215)',
       dark: 'rgb(86,87,87)',
     },
+    star: {
+      main: 'rgb(255, 196, 3)',
+    },
 
     body1: {
       textAlign: 'left',


### PR DESCRIPTION
## #️⃣ 연관이슈 

- close #22 

## 📝 작업 내용

메인 페이지의 인기 앨범 차트 디자인입니다.

차트 부분은 왼쪽과 오른쪽을 나누어 AlbumList함수에서 인덱스를 받아 쓰는 방식으로 만들었습니다.

## 의논할 거리
별점과 재사용 가능한 부분은 따로 나누면 좋지 않을까 회의에서 이야기 나누었었고
개인적으론 해당 코드에서 별점의 색을 Hex코드로 쓰고 있어 아직은 가독성이 떨어지는게 흠인듯 합니다.
그리고 폰트 크기나 사이즈, 마진을 다른데에서 가져오지않고 직접 써놓아서 만약 고칠 부분이 보이신다면 피드백 부탁드립니다!