### PR TITLE
리뷰 작성 시 앨범 평점 등록

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,8 @@
         "react/no-array-index-key":"off",
         "jsx-a11y/label-has-associated-control":"off",
         "no-shadow":"off",
-        "react/no-unescaped-entities":"off"
+        "react/no-unescaped-entities":"off",
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
     },
     "settings": {
       "import/resolver": {

--- a/src/components/AlbumReviewForm.tsx
+++ b/src/components/AlbumReviewForm.tsx
@@ -1,15 +1,16 @@
 import { useState } from 'react';
 import AlbumSearch from './AlbumSearch';
 import { AlbumSearchResult } from '../types/albumSearch';
-// import RatingAlbum from './RatingAlbum';
+import RatingAlbum from './RatingAlbum';
 
 function AlbumReviewForm() {
   const [searchResult, setSearchResult] = useState<AlbumSearchResult[] | null>(null);
-  const [, setSelectedAlbum] = useState<AlbumSearchResult | null>(null);
+  const [selectedAlbum, setSelectedAlbum] = useState<AlbumSearchResult | null>(null);
+  const [albumRating, setAlbumRating] = useState<number>(0.5);
   return (
     <>
       <AlbumSearch searchResult={searchResult} setSearchResult={setSearchResult} setSelectedAlbum={setSelectedAlbum} />
-      {/* {selectedAlbum && <RatingAlbum album={selectedAlbum!} />} */}
+      {selectedAlbum && <RatingAlbum album={selectedAlbum!} rating={albumRating} setRating={setAlbumRating} />}
     </>
   );
 }

--- a/src/components/AlbumReviewForm.tsx
+++ b/src/components/AlbumReviewForm.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import AlbumSearch from './AlbumSearch';
+import { AlbumSearchResult } from '../types/albumSearch';
+// import RatingAlbum from './RatingAlbum';
+
+function AlbumReviewForm() {
+  const [searchResult, setSearchResult] = useState<AlbumSearchResult[] | null>(null);
+  const [, setSelectedAlbum] = useState<AlbumSearchResult | null>(null);
+  return (
+    <>
+      <AlbumSearch searchResult={searchResult} setSearchResult={setSearchResult} setSelectedAlbum={setSelectedAlbum} />
+      {/* {selectedAlbum && <RatingAlbum album={selectedAlbum!} />} */}
+    </>
+  );
+}
+
+export default AlbumReviewForm;

--- a/src/components/AlbumReviewForm.tsx
+++ b/src/components/AlbumReviewForm.tsx
@@ -2,15 +2,23 @@ import { useState } from 'react';
 import AlbumSearch from './AlbumSearch';
 import { AlbumSearchResult } from '../types/albumSearch';
 import RatingAlbum from './RatingAlbum';
+import { AlbumForReview } from '../types/albumReview';
 
 function AlbumReviewForm() {
   const [searchResult, setSearchResult] = useState<AlbumSearchResult[] | null>(null);
-  const [selectedAlbum, setSelectedAlbum] = useState<AlbumSearchResult | null>(null);
-  const [albumRating, setAlbumRating] = useState<number>(0.5);
+  const [selectedAlbum, setSelectedAlbum] = useState<AlbumForReview | null>(null);
   return (
     <>
       <AlbumSearch searchResult={searchResult} setSearchResult={setSearchResult} setSelectedAlbum={setSelectedAlbum} />
-      {selectedAlbum && <RatingAlbum album={selectedAlbum!} rating={albumRating} setRating={setAlbumRating} />}
+      {selectedAlbum && (
+        <RatingAlbum
+          album={selectedAlbum!}
+          rating={selectedAlbum.rating!}
+          setRating={(rating: number) => {
+            setSelectedAlbum((prev) => ({ ...prev!, rating }));
+          }}
+        />
+      )}
     </>
   );
 }

--- a/src/components/AlbumSearch.tsx
+++ b/src/components/AlbumSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import SearchIcon from '@mui/icons-material/Search';
 import { Container, Input, InputAdornment } from '@mui/material';
 import { AlbumSearchResult } from '../types/albumSearch';
@@ -6,9 +6,14 @@ import postSearchAlbum from '../api/album';
 import useDebounce from '../utils/useDebounce';
 import Result from './AlbumSearchResult';
 
-function AlbumSearch() {
+interface AlbumSearchProps {
+  searchResult: AlbumSearchResult[] | null;
+  setSearchResult: Dispatch<SetStateAction<AlbumSearchResult[] | null>>;
+  setSelectedAlbum: Dispatch<SetStateAction<AlbumSearchResult | null>>;
+}
+
+function AlbumSearch({ searchResult, setSearchResult, setSelectedAlbum }: AlbumSearchProps) {
   const [keyword, setKeyword] = useState<string | null>(null);
-  const [searchResult, setSearchResult] = useState<AlbumSearchResult[] | null>(null);
 
   const { debouncedValue } = useDebounce(keyword!, 200);
   const isSearchCompleted = debouncedValue && searchResult;
@@ -23,7 +28,7 @@ function AlbumSearch() {
       const res = await postSearchAlbum(debouncedValue!);
       if (res.success) setSearchResult(res.data);
     })();
-  }, [debouncedValue]);
+  }, [debouncedValue, setSearchResult]);
 
   return (
     <Container>
@@ -44,7 +49,7 @@ function AlbumSearch() {
         sx={isSearchCompleted ? { borderBottomRightRadius: 0, borderBottomLeftRadius: 0 } : {}}
       />
 
-      {isSearchCompleted && <Result data={searchResult} />}
+      {isSearchCompleted && <Result data={searchResult} setSelectedAlbum={setSelectedAlbum} />}
     </Container>
   );
 }

--- a/src/components/AlbumSearch.tsx
+++ b/src/components/AlbumSearch.tsx
@@ -49,7 +49,14 @@ function AlbumSearch({ searchResult, setSearchResult, setSelectedAlbum }: AlbumS
         sx={isSearchCompleted ? { borderBottomRightRadius: 0, borderBottomLeftRadius: 0 } : {}}
       />
 
-      {isSearchCompleted && <Result data={searchResult} setSelectedAlbum={setSelectedAlbum} />}
+      {isSearchCompleted && (
+        <Result
+          data={searchResult}
+          setSelectedAlbum={setSelectedAlbum}
+          setSearchResult={setSearchResult}
+          setKeyword={setKeyword}
+        />
+      )}
     </Container>
   );
 }

--- a/src/components/AlbumSearch.tsx
+++ b/src/components/AlbumSearch.tsx
@@ -5,11 +5,12 @@ import { AlbumSearchResult } from '../types/albumSearch';
 import postSearchAlbum from '../api/album';
 import useDebounce from '../utils/useDebounce';
 import Result from './AlbumSearchResult';
+import { AlbumForReview } from '../types/albumReview';
 
 interface AlbumSearchProps {
   searchResult: AlbumSearchResult[] | null;
   setSearchResult: Dispatch<SetStateAction<AlbumSearchResult[] | null>>;
-  setSelectedAlbum: Dispatch<SetStateAction<AlbumSearchResult | null>>;
+  setSelectedAlbum: Dispatch<SetStateAction<AlbumForReview | null>>;
 }
 
 function AlbumSearch({ searchResult, setSearchResult, setSelectedAlbum }: AlbumSearchProps) {

--- a/src/components/AlbumSearchResult.tsx
+++ b/src/components/AlbumSearchResult.tsx
@@ -24,9 +24,13 @@ function ResultBox({ children }: { children: ReactNode }) {
 function Result({
   data,
   setSelectedAlbum,
+  setSearchResult,
+  setKeyword,
 }: {
   data: AlbumSearchResult[];
   setSelectedAlbum: Dispatch<SetStateAction<AlbumSearchResult | null>>;
+  setSearchResult: Dispatch<SetStateAction<AlbumSearchResult[] | null>>;
+  setKeyword: Dispatch<SetStateAction<string | null>>;
 }) {
   if (data.length === 0) return <ResultBox>검색 결과가 없습니다.</ResultBox>;
   return (
@@ -36,6 +40,8 @@ function Result({
           sx={{ display: 'flex', cursor: 'pointer' }}
           onClick={() => {
             setSelectedAlbum(album);
+            setKeyword(null);
+            setSearchResult(null);
           }}
         >
           <Box

--- a/src/components/AlbumSearchResult.tsx
+++ b/src/components/AlbumSearchResult.tsx
@@ -1,6 +1,8 @@
 import { Box, Typography } from '@mui/material';
 import { Dispatch, ReactNode, SetStateAction } from 'react';
 import { AlbumSearchResult } from '../types/albumSearch';
+import { AlbumForReview } from '../types/albumReview';
+import INITIAL_RATING_VALUE from './constants/rating';
 
 function ResultBox({ children }: { children: ReactNode }) {
   return (
@@ -28,7 +30,7 @@ function Result({
   setKeyword,
 }: {
   data: AlbumSearchResult[];
-  setSelectedAlbum: Dispatch<SetStateAction<AlbumSearchResult | null>>;
+  setSelectedAlbum: Dispatch<SetStateAction<AlbumForReview | null>>;
   setSearchResult: Dispatch<SetStateAction<AlbumSearchResult[] | null>>;
   setKeyword: Dispatch<SetStateAction<string | null>>;
 }) {
@@ -40,6 +42,7 @@ function Result({
           sx={{ display: 'flex', cursor: 'pointer' }}
           onClick={() => {
             setSelectedAlbum(album);
+            setSelectedAlbum((prev) => ({ ...prev!, rating: INITIAL_RATING_VALUE }));
             setKeyword(null);
             setSearchResult(null);
           }}

--- a/src/components/AlbumSearchResult.tsx
+++ b/src/components/AlbumSearchResult.tsx
@@ -1,6 +1,5 @@
 import { Box, Typography } from '@mui/material';
-import { ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Dispatch, ReactNode, SetStateAction } from 'react';
 import { AlbumSearchResult } from '../types/albumSearch';
 
 function ResultBox({ children }: { children: ReactNode }) {
@@ -22,13 +21,23 @@ function ResultBox({ children }: { children: ReactNode }) {
   );
 }
 
-function Result({ data }: { data: AlbumSearchResult[] }) {
-  const router = useNavigate();
+function Result({
+  data,
+  setSelectedAlbum,
+}: {
+  data: AlbumSearchResult[];
+  setSelectedAlbum: Dispatch<SetStateAction<AlbumSearchResult | null>>;
+}) {
   if (data.length === 0) return <ResultBox>검색 결과가 없습니다.</ResultBox>;
   return (
     <ResultBox>
       {data.map((album) => (
-        <Box sx={{ display: 'flex', cursor: 'pointer' }} onClick={() => router(`/album/${album.id}`)}>
+        <Box
+          sx={{ display: 'flex', cursor: 'pointer' }}
+          onClick={() => {
+            setSelectedAlbum(album);
+          }}
+        >
           <Box
             component="img"
             width="60px"

--- a/src/components/RatingAlbum.tsx
+++ b/src/components/RatingAlbum.tsx
@@ -1,5 +1,4 @@
 import { Box, Rating, Typography } from '@mui/material';
-import { Dispatch, SetStateAction } from 'react';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { AlbumSearchResult } from '../types/albumSearch';
@@ -13,15 +12,13 @@ const starIconStyle = {
   color: 'star.main',
 };
 
-function RatingAlbum({
-  album,
-  rating,
-  setRating,
-}: {
+type RatingAlbumProps = {
   album: AlbumSearchResult;
   rating: number;
-  setRating: Dispatch<SetStateAction<number>>;
-}) {
+  setRating: (_rating: number) => void;
+};
+
+function RatingAlbum({ album, rating, setRating }: RatingAlbumProps) {
   const { name, artists } = album;
   return (
     <Box

--- a/src/components/RatingAlbum.tsx
+++ b/src/components/RatingAlbum.tsx
@@ -1,0 +1,64 @@
+import { Box, Rating, Typography } from '@mui/material';
+import { Dispatch, SetStateAction } from 'react';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import { AlbumSearchResult } from '../types/albumSearch';
+import INITIAL_RATING_VALUE from './constants/rating';
+
+const starIconStyle = {
+  marginTop: '0.5px',
+  marginBottom: '0.5px',
+  width: '15px',
+  height: '15px',
+  color: 'star.main',
+};
+
+function RatingAlbum({
+  album,
+  rating,
+  setRating,
+}: {
+  album: AlbumSearchResult;
+  rating: number;
+  setRating: Dispatch<SetStateAction<number>>;
+}) {
+  const { name, artists } = album;
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        backgroundColor: 'rgb(52,52,52)',
+        borderRadius: '16px',
+        padding: '20px',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
+      <Box>
+        <Typography textAlign="left" fontWeight="fontWeightBold">
+          {name}
+        </Typography>
+        <Box sx={{ display: 'flex' }}>
+          {artists.map(({ name }, index) => (
+            <Typography color="grey.main">
+              {name} {artists.length > 1 && index < artists.length - 1 && '· '}
+            </Typography>
+          ))}
+        </Box>
+      </Box>
+
+      <Rating
+        name="albumRating"
+        value={rating}
+        icon={<StarIcon sx={{ ...starIconStyle }} />}
+        emptyIcon={<StarBorderIcon sx={{ ...starIconStyle }} />}
+        precision={INITIAL_RATING_VALUE}
+        onChange={(_, value: number | null) => {
+          setRating(value!);
+        }}
+      />
+    </Box>
+  );
+}
+
+export default RatingAlbum;

--- a/src/components/constants/rating.ts
+++ b/src/components/constants/rating.ts
@@ -1,0 +1,3 @@
+const INITIAL_RATING_VALUE = 0.5;
+
+export default INITIAL_RATING_VALUE;

--- a/src/types/albumReview.ts
+++ b/src/types/albumReview.ts
@@ -1,0 +1,5 @@
+import { AlbumSearchResult } from './albumSearch';
+
+export interface AlbumForReview extends AlbumSearchResult {
+  rating?: number | null;
+}


### PR DESCRIPTION
## #️⃣ 연관이슈 

- close #34

## 📝 작업 내용
* `AlbumReviewForm`
   - 리뷰 작성을 위한 값들이 등록되는 폼 컴포넌트 추가
### 앨범 평점 등록 프로세스
- 앨범 검색 (`AlbumSearch`) -> 앨범 선택 (`AlbumForReview`) -> 앨범 평점 등록 (`RatingAlbum`)
### 앨범 평점 등록 위한 앨범 선택
* `selectedAlbum` 상태 추가
* 앨범 검색 결과 에서 특정 앨범 을 클릭 하면 선택됨
* 앨범 선택 시, 앨범 검색 키워드, 결과 초기화
### 앨범 평점 등록 컴포넌트
* `RatingAlbum.tsx`
   - `props` : `album` (선택된 앨범), `rating`, `setRating` (평점)
* 초기 평점  값 인 `INITIAL_RATING_VALUE` 상수 추가

### 상수 관련 디렉토리 추가 
* `constants/` : 서비스 전반에서 사용되는 상수 들이 포함

### no-unused-vars 규칙 에 argsIgnorePattern 옵션 추가
* `function` 타입의 `props` 를 지정할 때 `no-unused-vars` 규칙에 위반되는 경우를 제외하기 위함. 변수 앞에 `_` 가 붙은 경우, 해당 규칙에 제한받지 않음.


## 의논할 거리
* 앨범 을 검색, 선택, 평점 을 매기는 로직과 관련된 상태가 여러 컴포넌트 에 걸쳐 `props` 로 전달되어, `context api` 를 사용할 까 고려했지만, 아직은 `depth` 가 그리 깊지 않아, `props` 로 전달하도록 두었습니다.
* 현재 선택된 앨범과, 앨범의 평점이 각각의 상태로 존재하는데, 묶어서 객체 타입의 상태로 관리하는 것도 고려해볼 수 있을 것 같습니다.
   - 객체 상태로 변경 완료했습니다. [커밋](https://github.com/hype-hop/hypehop-client/pull/37/commits/ab11a1cc426d5bcdecd7214cf5f18c35ff196ba9)