### PR TITLE
[FEAT]Edit 페이지 디자인 & 기능 수정

### DIFF
--- a/src/components/EditReview.tsx
+++ b/src/components/EditReview.tsx
@@ -1,23 +1,26 @@
 import Rating from '@mui/material/Rating';
 import Stack from '@mui/material/Stack';
 import { useState, useEffect } from 'react';
-import { Button } from '@mui/material';
+import { Button, Box, Input } from '@mui/material';
 import { useParams, useNavigate } from 'react-router-dom';
 import EditorBox from './EditorBox';
 import BASE_URL from '../config';
+import TrackListForEdit from './TrackListForEdit';
 
-function EditReview({ data /* id */ }) {
+function EditReview({ data }) {
   const navigate = useNavigate();
   const { id } = useParams();
   const [reviewContent, setReviewContent] = useState('');
+  const [parentTrackRatingForEdit, setParentTrackRatingForEdit] = useState(null);
+
+  const handleTrackRatingForEditUpdate = (updatedTrackRatingForEdit) => {
+    setParentTrackRatingForEdit(updatedTrackRatingForEdit);
+  };
+  // const [trackRating, setTrackRating] = useState<(number | null)[]>([]);
+
   const handleContentChange = (newContent) => {
     setReviewContent(newContent);
   };
-
-  // const tracksByDisc = {};
-  // const tracks = [];
-
-  // const [trackRating, setTrackRating] = useState([]);
 
   const [formData, setFormData] = useState({
     title: '',
@@ -25,17 +28,6 @@ function EditReview({ data /* id */ }) {
     albumRating: 0,
     body: '',
   });
-
-  /*
-  data?.albumData.tracks.items.forEach((track,index) => {
-      const discNumber = track.disc_number || 1; 
-      if (!tracksByDisc[discNumber]) {
-        tracksByDisc[discNumber] = [];
-      }
-      tracksByDisc[discNumber].push(track);
-      tracks.push(`disc${discNumber-1}-${index + 1}.${track.name}`)
-    });
-  */
 
   useEffect(() => {
     if (data) {
@@ -46,11 +38,8 @@ function EditReview({ data /* id */ }) {
         albumRating: data?.review.albumRating,
         body: data?.review.body,
       });
-
-      /*
-      const trackRatingArray = Array(data?.albumData.tracks.items.length || 0).fill(null);
-      setTrackRating(trackRatingArray);
-    */
+      // const trackRatingArray = Array(data?.albumData.tracks.items.length || 0).fill(null);
+      // setTrackRating(trackRatingArray);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
@@ -64,6 +53,7 @@ function EditReview({ data /* id */ }) {
     if (formData.albumRating !== 0 && formData.title !== '') {
       const combinedData = {
         ...formData,
+        tracks: parentTrackRatingForEdit,
         body: reviewContent,
       };
 
@@ -91,44 +81,15 @@ function EditReview({ data /* id */ }) {
     }
   };
 
-  /*
-    const renderTracks = Object.keys(tracksByDisc).map(discNumber => (
-      <div key={discNumber}>
-        <h3>Disc {discNumber}</h3>
-        <div style={{display:'flex', flexDirection:'column', alignItems:'center'}}>
-     
-          {tracksByDisc[discNumber].map((track, index) => (
-         
-        <div style={{display:'flex'}} key={index}> 
-        {index+1}. {track.name} - 
-        {trackRating && (
-  <Stack spacing={1}>
-    <Rating 
-      name="trackRating" 
-      value={trackRating[index]}
-      precision={0.5}
-      onChange={(event, newValue) => {
-        const updatedRating = [...trackRating];
-        updatedRating[index] = newValue;
-        setTrackRating(updatedRating);
-      }}
-    />
-  </Stack>
-)}
-
-      </div>
-      
-          ))}
-      
-        </div>
-      </div>
-    ));
-
-*/
-
   return (
     <div className="Edit-review">
-      <h3>작성페이지</h3>
+      <Box
+        component="img"
+        width="60px"
+        height="60px"
+        src={data?.review.thumbnail}
+        sx={{ borderRadius: '6.6px', marginRight: '20px' }}
+      />
 
       <form>
         <h5>앨범 평점:</h5>
@@ -139,16 +100,9 @@ function EditReview({ data /* id */ }) {
 
         <h5>트랙별 평점:</h5>
 
-        {/*
-    {renderTracks}
-  */}
+        <TrackListForEdit data={data} onUpdateTrackRatingForEdit={handleTrackRatingForEditUpdate} />
 
-        <div className="row">
-          <div className="input-field">
-            <input type="text" id="title" name="title" onChange={handleFormData} value={formData.title} required />
-            <label htmlFor="title">한줄평</label>
-          </div>
-        </div>
+        <div className="row" />
 
         <div className="row">
           <div className="input-field">
@@ -162,10 +116,21 @@ function EditReview({ data /* id */ }) {
           </div>
         </div>
 
-        <h5>리뷰 작성</h5>
-
         <div style={{ margin: '50px' }} className="row">
-          <h5>리뷰 작성하기:</h5>
+          <div className="input-field">
+            <Input
+              fullWidth
+              type="text"
+              id="title"
+              name="title"
+              onChange={handleFormData}
+              value={formData.title}
+              placeholder="제목을 입력하세요"
+              required
+              sx={{ mt: '16px' }}
+            />
+            <label htmlFor="title" />
+          </div>
 
           <EditorBox onContentChange={handleContentChange} value={formData.body} />
         </div>

--- a/src/components/EditReview.tsx
+++ b/src/components/EditReview.tsx
@@ -1,13 +1,13 @@
 import Rating from '@mui/material/Rating';
 import Stack from '@mui/material/Stack';
 import { useState, useEffect } from 'react';
-import { Button, Box, Input } from '@mui/material';
+import { Button, Box, Input, Typography, Container } from '@mui/material';
 import { useParams, useNavigate } from 'react-router-dom';
 import EditorBox from './EditorBox';
 import BASE_URL from '../config';
 import TrackListForEdit from './TrackListForEdit';
 
-function EditReview({ data }) {
+function EditReview({ data, albumData }) {
   const navigate = useNavigate();
   const { id } = useParams();
   const [reviewContent, setReviewContent] = useState('');
@@ -38,8 +38,6 @@ function EditReview({ data }) {
         albumRating: data?.review.albumRating,
         body: data?.review.body,
       });
-      // const trackRatingArray = Array(data?.albumData.tracks.items.length || 0).fill(null);
-      // setTrackRating(trackRatingArray);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
@@ -82,7 +80,7 @@ function EditReview({ data }) {
   };
 
   return (
-    <div className="Edit-review">
+    <Container className="Edit-review">
       <Box
         component="img"
         width="60px"
@@ -92,15 +90,59 @@ function EditReview({ data }) {
       />
 
       <form>
-        <h5>앨범 평점:</h5>
+        <Typography variant="h1">앨범 평점</Typography>
+        <Box
+          sx={{
+            mt: '16px',
+            background: 'rgb(52,52,52)',
+            borderRadius: '16px',
+            mb: '62px',
+          }}
+        >
+          <Stack sx={{ height: '74px', justifyContent: 'center', margin: '20px' }} spacing={1}>
+            <Box sx={{ display: 'flex' }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                <Typography
+                  textAlign="left"
+                  fontSize="fontSizeMd"
+                  fontWeight="fontWeightBold"
+                  sx={{ whiteSpace: 'nowrap' }}
+                >
+                  {albumData?.albumTitleOnly}
+                </Typography>
+                <Typography
+                  fontSize="fontSizeSm"
+                  fontWeight="fontWeightLight"
+                  sx={{ whiteSpace: 'nowrap', alignContent: 'center', color: 'grey.main' }}
+                >
+                  {data?.review.albumTitle}
+                </Typography>
+              </Box>
 
-        <Stack style={{ alignItems: 'center' }} spacing={1}>
-          <Rating name="albumRating" value={formData.albumRating} precision={0.5} onChange={handleFormData} />
-        </Stack>
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%', alignItems: 'center' }}>
+                <Rating
+                  size="small"
+                  name="albumRating"
+                  value={formData.albumRating}
+                  precision={0.5}
+                  onChange={handleFormData}
+                  sx={{ mr: '3px' }}
+                />
 
-        <h5>트랙별 평점:</h5>
+                <Typography fontSize="fontSizeMd" fontWeight="fontWeightRegular" sx={{ alignContent: 'center' }}>
+                  {Number(formData.albumRating).toFixed(1)}
+                </Typography>
+              </Box>
+            </Box>
+          </Stack>
+        </Box>
+        <Typography variant="h1">트랙별 평점</Typography>
 
-        <TrackListForEdit data={data} onUpdateTrackRatingForEdit={handleTrackRatingForEditUpdate} />
+        <TrackListForEdit
+          data={data}
+          onUpdateTrackRatingForEdit={handleTrackRatingForEditUpdate}
+          albumData={albumData}
+        />
 
         <div className="row" />
 
@@ -116,7 +158,10 @@ function EditReview({ data }) {
           </div>
         </div>
 
-        <div style={{ margin: '50px' }} className="row">
+        <Typography sx={{ mt: '62px' }} variant="h1">
+          리뷰 작성하기
+        </Typography>
+        <div className="row">
           <div className="input-field">
             <Input
               fullWidth
@@ -139,7 +184,7 @@ function EditReview({ data }) {
           Save
         </Button>
       </form>
-    </div>
+    </Container>
   );
 }
 

--- a/src/components/EditReview.tsx
+++ b/src/components/EditReview.tsx
@@ -3,6 +3,8 @@ import Stack from '@mui/material/Stack';
 import { useState, useEffect } from 'react';
 import { Button, Box, Input, Typography, Container } from '@mui/material';
 import { useParams, useNavigate } from 'react-router-dom';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import EditorBox from './EditorBox';
 import BASE_URL from '../config';
 import TrackListForEdit from './TrackListForEdit';
@@ -11,7 +13,8 @@ function EditReview({ data, albumData }) {
   const navigate = useNavigate();
   const { id } = useParams();
   const [reviewContent, setReviewContent] = useState('');
-  const [parentTrackRatingForEdit, setParentTrackRatingForEdit] = useState(null);
+  const [isTrackListOpened, SetsTrackListOpened] = useState(false);
+  const [parentTrackRatingForEdit, setParentTrackRatingForEdit] = useState(data?.review.tracks);
 
   const handleTrackRatingForEditUpdate = (updatedTrackRatingForEdit) => {
     setParentTrackRatingForEdit(updatedTrackRatingForEdit);
@@ -20,6 +23,10 @@ function EditReview({ data, albumData }) {
 
   const handleContentChange = (newContent) => {
     setReviewContent(newContent);
+  };
+
+  const handleOpen = () => {
+    SetsTrackListOpened(!isTrackListOpened);
   };
 
   const [formData, setFormData] = useState({
@@ -136,13 +143,52 @@ function EditReview({ data, albumData }) {
             </Box>
           </Stack>
         </Box>
-        <Typography variant="h1">트랙별 평점</Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Typography variant="h1">트랙별 평점</Typography>
 
-        <TrackListForEdit
-          data={data}
-          onUpdateTrackRatingForEdit={handleTrackRatingForEditUpdate}
-          albumData={albumData}
-        />
+          <Button size="small" variant="outlined" onClick={handleOpen}>
+            <Typography fontSize="fontSizeMd" fontWeight="fontWeightRegular">
+              {isTrackListOpened ? `트랙리스트 닫기` : '트랙리스트 열기'}
+            </Typography>
+            {isTrackListOpened ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </Button>
+        </Box>
+        {isTrackListOpened ? (
+          <TrackListForEdit
+            data={data}
+            onUpdateTrackRatingForEdit={handleTrackRatingForEditUpdate}
+            albumData={albumData}
+          />
+        ) : (
+          <Box
+            sx={{
+              mt: '16px',
+              background: 'rgb(52,52,52)',
+              borderRadius: '16px',
+              mb: '62px',
+              height: '46px',
+              alignContent: 'center',
+            }}
+          >
+            <Typography
+              fontSize="fontSizeMd"
+              fontWeight="fontWeightRegular"
+              ml="20px"
+              textAlign="left"
+              sx={{
+                color: 'grey.main',
+              }}
+            >
+              트랙리스트를 열어 확인하세요.
+            </Typography>
+          </Box>
+        )}
 
         <div className="row" />
 

--- a/src/components/EditorBox.jsx
+++ b/src/components/EditorBox.jsx
@@ -17,7 +17,7 @@ import { useLocation } from 'react-router-dom';
 function EditorBox({ onContentChange, value }) {
   const editorRef = useRef(null);
   const [isCreating, setIsCreating] = useState(null);
-  const [content, setContent] = useState(null);
+  const [content, setContent] = useState(null || ' ');
   const location = useLocation();
   useEffect(() => {
     if (location.pathname.includes('edit') /* && value */) {

--- a/src/components/EditorBox.jsx
+++ b/src/components/EditorBox.jsx
@@ -17,12 +17,18 @@ import { useLocation } from 'react-router-dom';
 function EditorBox({ onContentChange, value }) {
   const editorRef = useRef(null);
   const [isCreating, setIsCreating] = useState(null);
-  const [content, setContent] = useState(null || ' ');
+  const [content, setContent] = useState(null);
   const location = useLocation();
   useEffect(() => {
-    if (location.pathname.includes('edit') /* && value */) {
-      setIsCreating(false);
-      setContent(value);
+    console.log(value === '');
+    if (location.pathname.includes('edit')) {
+      if (value !== '') {
+        setIsCreating(false);
+        setContent(value);
+      }
+      if (value === null) {
+        setIsCreating(true);
+      }
     } else {
       setIsCreating(true);
     }

--- a/src/components/ReviewDetailLeft.tsx
+++ b/src/components/ReviewDetailLeft.tsx
@@ -8,7 +8,6 @@ import TimeSincePost from './TimeSincePost';
 // import Favorite from './Favorite';
 
 function ReviewDetailLeft({ data, albumData }) {
-  console.log(data);
   return (
     <Box sx={{ mb: '18px' }}>
       <Stack sx={{ display: 'flex', justifyContent: 'space-between' }}>

--- a/src/components/ReviewMain.jsx
+++ b/src/components/ReviewMain.jsx
@@ -171,7 +171,7 @@ function ReviewMain() {
                         letterSpacing: '-4%',
                       }}
                     >
-                      {review.body.replace(/<[^>]+>/g, '')}
+                      {review.body.replace(/<[^>]+>/g, ' ')}
                     </Typography>
                   </Box>
                 </Link>

--- a/src/components/TrackListForEdit.jsx
+++ b/src/components/TrackListForEdit.jsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
-import { Stack, Rating } from '@mui/material';
-import BASE_URL from '../config';
+import { Stack, Rating, Box, Typography } from '@mui/material';
+// import BASE_URL from '../config';
 
-function TrackListForEdit({ data, onUpdateTrackRatingForEdit }) {
+function TrackListForEdit({ data, onUpdateTrackRatingForEdit, albumData }) {
   const [trackRatingForEdit, setTrackRatingForEdit] = useState(null);
   const [, setTrackRating] = useState(null);
-  const [albumData, setAlbumData] = useState(null);
+  // const [albumData] = useState(null);
 
   const id = data?.review.albumId;
   const tracksByDisc = {};
@@ -20,6 +20,7 @@ function TrackListForEdit({ data, onUpdateTrackRatingForEdit }) {
 
   useEffect(() => {
     if (id) {
+      /*
       const fetchData = async () => {
         try {
           const response = await fetch(`${BASE_URL}/album/api/${id}`);
@@ -30,11 +31,11 @@ function TrackListForEdit({ data, onUpdateTrackRatingForEdit }) {
           console.error('Error fetching data:', error);
         }
       };
+      fetchData();
+*/
       setTrackRatingForEdit(data?.review.tracks);
       const trackRatingArray = Array(data?.review.tracks.length || 0).fill(null);
       setTrackRating(trackRatingArray);
-
-      fetchData();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, data]);
@@ -49,28 +50,61 @@ function TrackListForEdit({ data, onUpdateTrackRatingForEdit }) {
   });
 
   return (
-    <div className="TrackList">
+    <Box
+      sx={{
+        mt: '16px',
+        background: 'rgb(52,52,52)',
+        borderRadius: '16px',
+        height: 'auto',
+        overflow: 'scroll',
+      }}
+    >
       {trackRatingForEdit?.map((album, albumIndex) => (
-        <div key={album._id}>
-          <h3>Disc Number: {album.discNumber}</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <Box key={album._id} sx={{ margin: '20px' }}>
+          <Typography variant="h1" textAlign="left" sx={{ mb: '5px' }}>
+            Disc Number: {album.discNumber}
+          </Typography>
+          <Box style={{ display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', width: '100%' }}>
             {album.trackTitle.map((title, trackIndex) => (
-              <div style={{ display: 'flex' }} key={trackIndex}>
-                {title} -
-                <Stack spacing={1}>
-                  <Rating
-                    name="trackRating"
-                    value={album.trackRating[trackIndex]}
-                    precision={0.5}
-                    onChange={(event, newValue) => handleRatingChange(event, newValue, albumIndex, trackIndex)}
-                  />
-                </Stack>
-              </div>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: '5px' }} key={trackIndex}>
+                <Box>
+                  <Typography
+                    textAlign="left"
+                    fontSize="fontSizeMd"
+                    fontWeight="fontWeightBold"
+                    sx={{ whiteSpace: 'nowrap' }}
+                  >
+                    {title}
+                  </Typography>
+                  <Typography
+                    textAlign="left"
+                    fontSize="fontSizeSm"
+                    fontWeight="fontWeightLight"
+                    sx={{ whiteSpace: 'nowrap', alignContent: 'center', color: 'grey.main' }}
+                  >
+                    {data?.review.albumTitle}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex' }}>
+                  <Stack spacing={1} sx={{ mr: '3px', justifyContent: 'center' }}>
+                    <Rating
+                      size="small"
+                      name="trackRating"
+                      value={album.trackRating[trackIndex]}
+                      precision={0.5}
+                      onChange={(event, newValue) => handleRatingChange(event, newValue, albumIndex, trackIndex)}
+                    />
+                  </Stack>
+                  <Typography fontSize="fontSizeMd" fontWeight="fontWeightRegular" sx={{ alignContent: 'center' }}>
+                    {Number(album.trackRating[trackIndex]).toFixed(1)}
+                  </Typography>
+                </Box>
+              </Box>
             ))}
-          </div>
-        </div>
+          </Box>
+        </Box>
       ))}
-    </div>
+    </Box>
   );
 }
 

--- a/src/components/TrackListForEdit.jsx
+++ b/src/components/TrackListForEdit.jsx
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+import { Stack, Rating } from '@mui/material';
+import BASE_URL from '../config';
+
+function TrackListForEdit({ data, onUpdateTrackRatingForEdit }) {
+  const [trackRatingForEdit, setTrackRatingForEdit] = useState(null);
+  const [, setTrackRating] = useState(null);
+  const [albumData, setAlbumData] = useState(null);
+
+  const id = data?.review.albumId;
+  const tracksByDisc = {};
+  const tracks = [];
+
+  const handleRatingChange = (event, newValue, albumIndex, trackIndex) => {
+    const updatedState = [...trackRatingForEdit];
+    updatedState[albumIndex].trackRating[trackIndex] = newValue;
+    setTrackRatingForEdit(updatedState);
+    onUpdateTrackRatingForEdit(updatedState);
+  };
+
+  useEffect(() => {
+    if (id) {
+      const fetchData = async () => {
+        try {
+          const response = await fetch(`${BASE_URL}/album/api/${id}`);
+
+          const result = await response.json();
+          setAlbumData(result);
+        } catch (error) {
+          console.error('Error fetching data:', error);
+        }
+      };
+      setTrackRatingForEdit(data?.review.tracks);
+      const trackRatingArray = Array(data?.review.tracks.length || 0).fill(null);
+      setTrackRating(trackRatingArray);
+
+      fetchData();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, data]);
+
+  albumData?.albumData?.tracks.items.forEach((track, index) => {
+    const discNumber = track.disc_number || 1;
+    if (!tracksByDisc[discNumber]) {
+      tracksByDisc[discNumber] = [];
+    }
+    tracksByDisc[discNumber].push(track);
+    tracks.push(`disc${discNumber - 1}-${index + 1}.${track.name}`);
+  });
+
+  return (
+    <div className="TrackList">
+      {trackRatingForEdit?.map((album, albumIndex) => (
+        <div key={album._id}>
+          <h3>Disc Number: {album.discNumber}</h3>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            {album.trackTitle.map((title, trackIndex) => (
+              <div style={{ display: 'flex' }} key={trackIndex}>
+                {title} -
+                <Stack spacing={1}>
+                  <Rating
+                    name="trackRating"
+                    value={album.trackRating[trackIndex]}
+                    precision={0.5}
+                    onChange={(event, newValue) => handleRatingChange(event, newValue, albumIndex, trackIndex)}
+                  />
+                </Stack>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default TrackListForEdit;

--- a/src/components/TrackRatingCard.tsx
+++ b/src/components/TrackRatingCard.tsx
@@ -9,7 +9,6 @@ function TrackRatingCard({ data }) {
       sx={{
         ml: '67px',
         width: '287px',
-        // height: '336px',
         height: '500px',
         padding: '16px',
         overflow: 'auto',
@@ -71,7 +70,8 @@ function TrackRatingCard({ data }) {
                           >
                             {' '}
                             {/* eslint-disable-next-line no-unsafe-optional-chaining */}
-                            {data?.review.tracks[index].trackRating && data?.review.tracks[index].trackRating[index]
+                            {data?.review.tracks[index].trackRating &&
+                            data?.review.tracks[index].trackRating[trackIndex]
                               ? Number(data?.review.tracks[index].trackRating[trackIndex]).toFixed(1)
                               : '--'}
                           </Typography>

--- a/src/components/WriteReview.jsx
+++ b/src/components/WriteReview.jsx
@@ -35,6 +35,8 @@ function WriteReview({ data, userData }) {
     albumRating: 0,
     body: '',
     albumTitle: data?.pageTitle,
+    // artistNameOnly: data?.artistNameOnly,
+    // albumTitleOnly: data?.albumTitleOnly,
     albumId: data?.albumData.id,
     thumbnail: data?.albumData.images[1].url,
     user: userData?._id,

--- a/src/pages/EditPage.jsx
+++ b/src/pages/EditPage.jsx
@@ -7,6 +7,7 @@ function EditPage() {
   const { id } = useParams();
 
   const [data, setData] = useState(null);
+  const [albumData, setAlbumData] = useState(null);
   const [, setIsAuthenticated] = useState(true);
 
   useEffect(() => {
@@ -18,6 +19,12 @@ function EditPage() {
         });
         const result = await response.json();
         setData(result);
+        const response2 = await fetch(`${BASE_URL}/album/api/${data?.review.albumId}`, {
+          method: 'GET',
+          credentials: 'include',
+        });
+        const result2 = await response2.json();
+        setAlbumData(result2);
       } catch (error) {
         console.error('Error fetching data:', error);
         setIsAuthenticated(false);
@@ -25,11 +32,11 @@ function EditPage() {
     };
 
     fetchData();
-  }, [id]);
+  }, [data?.review.albumId, id]);
 
   return (
     <div className="Edit-review">
-      <EditReview data={data} id={id} />
+      <EditReview data={data} id={id} albumData={albumData} />
     </div>
   );
 }

--- a/src/pages/EditPage.jsx
+++ b/src/pages/EditPage.jsx
@@ -29,9 +29,6 @@ function EditPage() {
 
   return (
     <div className="Edit-review">
-      <h3>EditPage.jsx</h3>
-      <h4>작업중..</h4>
-
       <EditReview data={data} id={id} />
     </div>
   );

--- a/src/pages/ReviewsPage.tsx
+++ b/src/pages/ReviewsPage.tsx
@@ -236,7 +236,7 @@ function ReviewsPage() {
                         letterSpacing: '-4%',
                       }}
                     >
-                      {review.body.replace(/<[^>]+>/g, '')}
+                      {review.body.replace(/<[^>]+>/g, ' ')}
                     </Typography>
                   </Box>
                 </Link>

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -88,6 +88,8 @@ const theme = createTheme({
         root: {
           padding: 0,
         },
+      },
+    },
     MuiInput: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
## #️⃣ 연관이슈 

- close #39  

## 📝 작업 내용

수정페이지 Editor 작업
- 수정모드에서 빈 텍스트 처리
- 트랙별 평점 수정 기능 추가 
- TrackListForEdit 컴포넌트 생성 (트랙별 평점 컴포넌트)
- 수정 오류 fix : 트랙별 평점 안바꿨을때 오류나는 현상

Theme 오류 수정
- bracket misplacement

메인페이지 최근리뷰
- 메인페이지 리뷰 공백없이 보여지는 현상 수정

리뷰상세페이지
- 리뷰상세 트랙별 평점 수정 (disc 별로 평점 나타내기)

디자인작업
- 수정페이지 앨범 평점 + 트랙별 평점
- 트랙별 평점 토글 

## 의논할 거리
-