### PR TITLE
좋아요 누른 유저 확인 모달

### DIFF
--- a/src/assets/icons/modal-close.svg
+++ b/src/assets/icons/modal-close.svg
@@ -1,0 +1,7 @@
+<svg width="18.000000" height="18.000000" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<desc>
+			Created with Pixso.
+	</desc>
+	<defs/>
+	<path id="path" d="M1.8 18L0 16.19L7.19 9L0 1.8L1.8 0L9 7.19L16.19 0L18 1.8L10.8 9L18 16.19L16.19 18L9 10.8L1.8 18Z" fill="#FFFFFF" fill-opacity="1.000000" fill-rule="nonzero"/>
+</svg>

--- a/src/components/common/Favorite.tsx
+++ b/src/components/common/Favorite.tsx
@@ -3,12 +3,14 @@ import { Typography, Box } from '@mui/material';
 // import { useAuth } from '../AuthenticationContext';
 import BASE_URL from '../../config';
 import { ReactComponent as EmptyFavoriteIcon } from '../../assets/icons/empty-favorite.svg';
+import FavoriteListCheckModal from './Modal/FavoriteListCheckModal';
 
 function Favorite({ reviewId, numberOfFavorite }) {
   // const { user } = useAuth();
 
   const [isFavorite, setIsFavorite] = useState(false);
   const [user, setUser] = useState(null);
+  const [open, setOpen] = useState(false);
 
   // const [data, setData] = useState(null);
 
@@ -23,6 +25,7 @@ function Favorite({ reviewId, numberOfFavorite }) {
         const favoritedReview = Object.keys(result.user.favoritesReview);
 
         // setData(favoritedReview);
+
         setUser(result);
         setIsFavorite(favoritedReview.includes(reviewId));
       } catch (error) {
@@ -66,9 +69,10 @@ function Favorite({ reviewId, numberOfFavorite }) {
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', columnGap: '1px' }}>
       <EmptyFavoriteIcon onClick={addToFavorite} fill={isFavorite ? 'red' : '#7e7e7e'} />
-      <Typography component="div" color="grey.main" fontSize="fontSizeSm">
+      <Typography onClick={() => setOpen(true)} component="div" color="grey.main" fontSize="fontSizeSm">
         좋아요 {numberOfFavorite}개,
       </Typography>
+      <FavoriteListCheckModal open={open} setOpen={setOpen} />
     </Box>
   );
 }

--- a/src/components/common/Favorite.tsx
+++ b/src/components/common/Favorite.tsx
@@ -66,10 +66,15 @@ function Favorite({ reviewId, numberOfFavorite }) {
     }
   };
 
+  const openFavoriteListCheckModal = () => {
+    if (numberOfFavorite === 0) return;
+    setOpen(true);
+  };
+
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', columnGap: '1px' }}>
       <EmptyFavoriteIcon onClick={addToFavorite} fill={isFavorite ? 'red' : '#7e7e7e'} />
-      <Typography onClick={() => setOpen(true)} component="div" color="grey.main" fontSize="fontSizeSm">
+      <Typography onClick={() => openFavoriteListCheckModal()} component="div" color="grey.main" fontSize="fontSizeSm">
         좋아요 {numberOfFavorite}개,
       </Typography>
       <FavoriteListCheckModal open={open} setOpen={setOpen} />

--- a/src/components/common/Modal/FavoriteListCheckModal.tsx
+++ b/src/components/common/Modal/FavoriteListCheckModal.tsx
@@ -1,19 +1,19 @@
 import { Avatar, Box, Modal, Typography, List, ListItem, ListItemAvatar } from '@mui/material';
 import { Dispatch, SetStateAction } from 'react';
 import { ReactComponent as Close } from '../../../assets/icons/modal-close.svg';
+import { FavoriteClickedUser } from '../../../types/favorite';
 
-interface FavoriteClickedUser {
-  name: string;
-  profileImageUrl: string;
-}
-
-function FavoriteListCheckModal({ open, setOpen }: { open: boolean; setOpen: Dispatch<SetStateAction<boolean>> }) {
+function FavoriteListCheckModal({
+  open,
+  setOpen,
+  favoriteClickedUsers,
+}: {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  favoriteClickedUsers: FavoriteClickedUser[];
+}) {
   const handleClose = () => setOpen(false);
-  const favorites: FavoriteClickedUser[] = [
-    { name: 'hhjh', profileImageUrl: 'fff' },
-    { name: 'hhjh', profileImageUrl: 'fff' },
-    { name: 'hhjh', profileImageUrl: 'fff' },
-  ];
+
   return (
     <Modal open={open} onClose={handleClose}>
       <Box
@@ -28,7 +28,7 @@ function FavoriteListCheckModal({ open, setOpen }: { open: boolean; setOpen: Dis
           background: 'rgb(27, 27, 27)',
           width: '90%',
           maxWidth: '650px',
-          height: '296px',
+          maxHeight: '296px',
           outline: 'none',
         }}
       >
@@ -47,11 +47,16 @@ function FavoriteListCheckModal({ open, setOpen }: { open: boolean; setOpen: Dis
             좋아요
           </Typography>
         </Box>
-        <List>
-          {favorites.map(({ name, profileImageUrl }) => (
+        <List
+          sx={{
+            maxHeight: '230px',
+            overflowY: 'scroll',
+          }}
+        >
+          {favoriteClickedUsers?.map(({ name, image }) => (
             <ListItem key={name} sx={{ height: '76px', paddingX: '16px', alignItems: 'center', cursor: 'pointer' }}>
               <ListItemAvatar>
-                <Avatar sx={{ width: '35px', height: '35px' }} src={profileImageUrl} />
+                <Avatar sx={{ width: '35px', height: '35px' }} src={image} />
               </ListItemAvatar>
               <Typography fontSize="20px">{name}</Typography>
             </ListItem>

--- a/src/components/common/Modal/FavoriteListCheckModal.tsx
+++ b/src/components/common/Modal/FavoriteListCheckModal.tsx
@@ -1,0 +1,65 @@
+import { Avatar, Box, Modal, Typography, List, ListItem, ListItemAvatar } from '@mui/material';
+import { Dispatch, SetStateAction } from 'react';
+import { ReactComponent as Close } from '../../../assets/icons/modal-close.svg';
+
+interface FavoriteClickedUser {
+  name: string;
+  profileImageUrl: string;
+}
+
+function FavoriteListCheckModal({ open, setOpen }: { open: boolean; setOpen: Dispatch<SetStateAction<boolean>> }) {
+  const handleClose = () => setOpen(false);
+  const favorites: FavoriteClickedUser[] = [
+    { name: 'hhjh', profileImageUrl: 'fff' },
+    { name: 'hhjh', profileImageUrl: 'fff' },
+    { name: 'hhjh', profileImageUrl: 'fff' },
+  ];
+  return (
+    <Modal open={open} onClose={handleClose}>
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          boxSizing: 'border-box',
+          transform: 'translate(-50%, -50%)',
+          border: '1px solid rgb(52, 52, 52)',
+          borderRadius: '16px',
+          background: 'rgb(27, 27, 27)',
+          width: '90%',
+          maxWidth: '650px',
+          height: '296px',
+          outline: 'none',
+        }}
+      >
+        <Box
+          sx={{
+            position: 'relative',
+            display: 'flex',
+            height: '66px',
+            justifyContent: 'center',
+            alignItems: 'center',
+            borderBottom: '1px solid rgb(196, 196, 196)',
+          }}
+        >
+          <Close onClick={() => setOpen(false)} style={{ position: 'absolute', top: 24, right: 20 }} />
+          <Typography component="div" fontWeight="bold" fontSize="24px">
+            좋아요
+          </Typography>
+        </Box>
+        <List>
+          {favorites.map(({ name, profileImageUrl }) => (
+            <ListItem key={name} sx={{ height: '76px', paddingX: '16px', alignItems: 'center', cursor: 'pointer' }}>
+              <ListItemAvatar>
+                <Avatar sx={{ width: '35px', height: '35px' }} src={profileImageUrl} />
+              </ListItemAvatar>
+              <Typography fontSize="20px">{name}</Typography>
+            </ListItem>
+          ))}
+        </List>
+      </Box>
+    </Modal>
+  );
+}
+
+export default FavoriteListCheckModal;

--- a/src/components/review/AlbumReviewSummary.tsx
+++ b/src/components/review/AlbumReviewSummary.tsx
@@ -124,7 +124,7 @@ function AlbumReviewSummary({ review }: { review: Review }) {
             columnGap: '8px',
           }}
         >
-          <Favorite reviewId={_id} numberOfFavorite={isFavorite.length} />
+          <Favorite reviewId={_id} favoriteClickedUsers={isFavorite} />
           <Link
             to={`/album/review/${_id}`}
             style={{ display: 'inline-flex', textDecoration: 'none', color: 'inherit' }}

--- a/src/components/review/ReviewMain.jsx
+++ b/src/components/review/ReviewMain.jsx
@@ -182,7 +182,7 @@ function ReviewMain() {
                     display: 'flex',
                   }}
                 >
-                  <Favorite reviewId={review._id} numberOfFavorite={review.isFavorite.length} />
+                  <Favorite reviewId={review._id} favoriteClickedUsers={review.isFavorite} />
 
                   <Box sx={{ display: 'flex' }}>
                     <Link

--- a/src/pages/ReviewShowPage.jsx
+++ b/src/pages/ReviewShowPage.jsx
@@ -46,7 +46,7 @@ function ReviewShowPage() {
           />
 
           <Box display="flex">
-            <Favorite reviewId={id} numberOfFavorite={data?.review.isFavorite.length} />
+            <Favorite reviewId={id} favoriteClickedUsers={data?.review.isFavorite} />
             <ChatBubbleOutline sx={{ color: 'white.main', fontSize: '1em' }} />
             <Typography sx={{ color: 'rgb(168,168,168)', fontSize: '12px', margin: '0px 8px' }}>
               댓글 {data?.comments.length}개

--- a/src/pages/ReviewsPage.tsx
+++ b/src/pages/ReviewsPage.tsx
@@ -247,7 +247,7 @@ function ReviewsPage() {
                     display: 'flex',
                   }}
                 >
-                  <Favorite reviewId={review._id} numberOfFavorite={review.isFavorite.length} />
+                  <Favorite reviewId={review._id} favoriteClickedUsers={review.isFavorite} />
 
                   <Box sx={{ display: 'flex' }}>
                     <Link

--- a/src/types/favorite.d.ts
+++ b/src/types/favorite.d.ts
@@ -1,0 +1,5 @@
+export interface FavoriteClickedUser {
+  image: string;
+  name: string;
+  _id: string;
+}

--- a/src/types/review.d.ts
+++ b/src/types/review.d.ts
@@ -1,3 +1,4 @@
+import { FavoriteClickedUser } from './favorite';
 import { User } from './user';
 
 export interface CommentType {
@@ -14,7 +15,7 @@ export interface Review {
   thumbnail: string;
   createdAt: string;
   user: User;
-  isFavorite: Array<string>;
+  isFavorite: Array<FavoriteClickedUser>;
   comments: Array<Comment>;
   albumRating: number;
 }


### PR DESCRIPTION
## #️⃣ 연관이슈 

- close #60

## 📝 작업 내용

# FavoriteListCheckModal
- `좋아요 누른 유저` 를 확인하는 Modal
```ts
   // 좋아요 누른 유저
   interface FavoriteClickedUser {
   image: string;
   name: string;
   _id: string;
}
```
- 좋아요 가 0 일 경우, 뜨지 않음
- `좋아요 누른 유저` interface  
 

# Favorite
   - favoriteClickedUsers(좋아요 누른 유저 데이터) props 추가
      - `FavoriteListCheckModal` 에 전달하기 위함
   - `numberOfFavorite` props 제거
      - `favoriteClickedUsers` 의 `length` 로 가져올 수 있기 때문
   - 좋아요 를 눌렀을 때, 그 결과를 뷰에 반영하기 위한 `favoriteCount` 상태 추가

## 의논할 거리
- 좋아요 누른 유저 데이터 를 현재 별개로 만들었는데, 유저에 관한 데이터이기 때문에 기존 유저에 관한 데이터 로 사용하고 있는 `GET /api/user` 의 응답 데이터 를 사용하면 좋을 것 같다는 생각이 들었습니다. 확장성과 재사용성에 용이할 것 같습니다!