### PR TITLE
메뉴 분리 및 헤더 수정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,24 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import {
-  AppBar,
-  Box,
-  Toolbar,
-  IconButton,
-  MenuItem,
-  Menu,
-  Typography,
-  styled,
-  MenuProps,
-  MenuItemProps,
-  Button,
-  Avatar,
-} from '@mui/material';
+import { AppBar, Box, Toolbar, IconButton, Typography, Button, Avatar } from '@mui/material';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import PersonIcon from '@mui/icons-material/Person';
 import LogoutIcon from '@mui/icons-material/Logout';
 
 import { useEffect, useState } from 'react';
+import { StyledMenu, StyledMenuItem } from './StyledMenu';
 
 import { ReactComponent as LogoMainIcon } from '../../assets/icons/logo-main.svg';
 import { ReactComponent as LogoSubIcon } from '../../assets/icons/logo-hover.svg';
@@ -29,41 +17,6 @@ import BASE_URL from '../../config';
 import fetchNotification from '../../api/notification';
 import { Notification } from '../../types/notification';
 import TimeSincePost from '../album/TimeSincePost';
-
-const HeaderMenu = styled((props: MenuProps) => (
-  <Menu
-    anchorOrigin={{
-      vertical: 'bottom',
-      horizontal: 'right',
-    }}
-    keepMounted
-    transformOrigin={{
-      vertical: 'top',
-      horizontal: 'right',
-    }}
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    {...props}
-  />
-))(({ theme }) => ({
-  '& .MuiMenu-paper': {
-    borderRadius: 16,
-    minWidth: 256,
-    boxShadow: '0px 0px 8px 0px rgba(0, 0, 0, 0.4)',
-    backgroundColor: theme.palette.background.default,
-    outline: '1px solid rgb(47, 47, 47)',
-  },
-  '& .MuiMenu-list': {
-    padding: 8,
-  },
-}));
-
-const HeaderMenuItem = styled((props: MenuItemProps) => (
-  <MenuItem
-    sx={{ borderRadius: '8px', ':hover': { backgroundColor: 'rgb(46, 45, 45)' } }}
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    {...props}
-  />
-))();
 
 function LogoHoverIcon() {
   const [count, setCount] = useState(false);
@@ -189,71 +142,97 @@ export default function MenuAppBar() {
                 />
               </IconButton>
 
-              <HeaderMenu
+              <StyledMenu
                 id="menu-notifications"
                 anchorEl={anchorNoti}
                 open={Boolean(anchorNoti)}
                 onClose={handleCloseNoti}
+                width={256}
               >
                 {notifications.length === 0 ? (
-                  <HeaderMenuItem disabled>
+                  <StyledMenuItem disabled>
                     <Typography>새로운 알림이 없습니다.</Typography>
-                  </HeaderMenuItem>
+                  </StyledMenuItem>
                 ) : (
                   notifications.map((noti) => (
                     <Link
                       to={`/album/review/${noti.review_id._id}`}
                       style={{ textDecoration: 'none', color: 'inherit' }}
                     >
-                      <HeaderMenuItem onClick={handleCloseNoti}>
-                        <Typography>{noti.sender_id.name}님이&nbsp; </Typography>
-                        <Typography>{noti.review_id.title}에&nbsp;</Typography>
-                        {noti.type === '좋아요' ? (
-                          <Typography>{noti.type} 표시를 했습니다.</Typography>
-                        ) : (
-                          <Typography>{noti.type}을 달았습니다.</Typography>
-                        )}
-                        <Typography fontSize={typography.size.md}>{noti.text}</Typography>
+                      <StyledMenuItem onClick={handleCloseNoti}>
+                        <Box sx={{ flexDirection: 'column' }}>
+                          <Typography>
+                            {noti.sender_id.name}님이&nbsp;
+                            {noti.review_id.title}에&nbsp;
+                          </Typography>
+                          <Typography>
+                            {noti.type === '좋아요' ? `${noti.type} 표시를 했습니다.` : `${noti.type}을 달았습니다.`}
+                          </Typography>
+                          <Typography fontSize={typography.size.md}>{noti.text}</Typography>
+                        </Box>
                         <Typography
                           fontWeight="light"
                           fontSize={typography.size.md}
                           sx={{
+                            // position: 'absolute',
+                            // bottom: '8px',
+                            // right: '8px',
                             paddingLeft: '4px',
                             color: 'rgb(126, 126, 126)',
                           }}
                         >
                           <TimeSincePost createdAt={noti.timestamp} />
                         </Typography>
-                      </HeaderMenuItem>
+                      </StyledMenuItem>
                     </Link>
                   ))
                 )}
-              </HeaderMenu>
+                <Link
+                  to="/dashboard"
+                  onClick={handleCloseNoti}
+                  style={{
+                    textDecoration: 'none',
+                    color: 'inherit',
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      margin: '8px 0 8px 16px',
+                      ':hover': {
+                        textDecorationLine: 'underline',
+                      },
+                    }}
+                  >
+                    더보기
+                  </Typography>
+                </Link>
+              </StyledMenu>
 
-              <HeaderMenu
+              <StyledMenu
                 id="menu-appbar"
                 anchorEl={anchorProfile}
                 open={Boolean(anchorProfile)}
                 onClose={handleCloseProfile}
+                width={200}
               >
                 <Link to="/dashboard" style={{ textDecorationLine: 'none' }}>
-                  <HeaderMenuItem onClick={handleCloseProfile}>
+                  <StyledMenuItem onClick={handleCloseProfile}>
                     <PersonIcon sx={{ marginRight: '16px', color: 'white.main' }} />
                     <Typography fontSize={typography.size.md} sx={{ color: 'white.main' }}>
                       마이프로필
                     </Typography>
-                  </HeaderMenuItem>
+                  </StyledMenuItem>
                 </Link>
 
                 <Link to={`${BASE_URL}/api/logout`} style={{ textDecorationLine: 'none' }}>
-                  <HeaderMenuItem onClick={handleChange}>
+                  <StyledMenuItem onClick={handleChange}>
                     <LogoutIcon sx={{ marginRight: '16px', color: 'white.main' }} />
                     <Typography fontSize={typography.size.md} sx={{ color: 'white.main' }}>
                       로그아웃
                     </Typography>
-                  </HeaderMenuItem>
+                  </StyledMenuItem>
                 </Link>
-              </HeaderMenu>
+              </StyledMenu>
             </div>
           ) : (
             <div>

--- a/src/components/common/StyledMenu.tsx
+++ b/src/components/common/StyledMenu.tsx
@@ -1,0 +1,50 @@
+import { Menu, MenuItem, MenuProps, MenuItemProps, styled } from '@mui/material';
+
+function StyledMenu({ width, ...props }: { width: number } & MenuProps) {
+  const TempMenu = styled((p: MenuProps) => (
+    <Menu
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'right',
+      }}
+      keepMounted
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'right',
+      }}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...p}
+    />
+  ))(({ theme }) => ({
+    '& .MuiMenu-paper': {
+      borderRadius: 16,
+      minWidth: width,
+      maxWidth: width,
+      boxShadow: '0px 0px 8px 0px rgba(0, 0, 0, 0.4)',
+      backgroundColor: theme.palette.background.default,
+      outline: '1px solid rgb(47, 47, 47)',
+    },
+    '& .MuiMenu-list': {
+      padding: 8,
+    },
+  }));
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <TempMenu {...props} />;
+}
+
+const StyledMenuItem = styled((props: MenuItemProps) => (
+  <MenuItem
+    sx={{
+      height: 'auto',
+      backgroundColor: 'background.default',
+      borderRadius: '8px',
+      ':hover': { backgroundColor: 'rgb(46, 45, 45)' },
+    }}
+    style={{ whiteSpace: 'normal' }}
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    {...props}
+  />
+))();
+
+export { StyledMenu, StyledMenuItem };


### PR DESCRIPTION
## #️⃣ 연관이슈 

- close #65 

## 📝 작업 내용

- StyledMenu 컴포넌트 추가
> - `import { StyledMenu, StyledMenuItem } from './StyledMenu';`로 메뉴 사용 가능
> - `<StyledMenu width={200} />` 와 같은 형식으로 메뉴 넓이 지정, 높이는 오토 사용 중

- 헤더 디자인 수정
> - Notification매뉴 좌측 하단에 더보기 추가
> - Notification에서 내용과 TimeSincePost를 Box로 구분
> - StyledMenuItem의 길이가 길어지면 `style={{ whiteSpace: 'normal' }}`로 줄 나눔

## 의논할 거리
Notification에서 TimeSincePost의 위치를 현재는 `paddingLeft: '4px'`로 정해주고 있는데 
Notification의 내용이 길어지면 위아래도 위치를 변경해도 위치가 애매해 보여서 
```ts
// position: 'absolute',
// bottom: '8px',
// right: '8px',
```
임시로 우측 하단에 위치 시켜놓는 코드를 넣었습니다.

이거는 디자이너 분들과 의논해 보는 것도 좋을듯합니다.