### PR TITLE
fix:로그아웃 상태에서 다른 유저 프로필 확인

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -5,7 +5,7 @@ import ensureError from '../utils/error';
 
 async function getProfile(id: string): Promise<Result<Profile>> {
   try {
-    const response = await fetch(`${BASE_URL}/api/user/${id}`, {
+    const response = await fetch(`${BASE_URL}/api/userReviews/${id}`, {
       method: 'GET',
       credentials: 'include',
     });

--- a/src/components/review/Reviews.tsx
+++ b/src/components/review/Reviews.tsx
@@ -28,7 +28,7 @@ export default function Reviews({
             minWidth: { xs: '100%', sm: '282px' },
           }}
         >
-          {user[0]._id === review.user ? (
+          {user[0]?._id === review.user ? (
             <ProfileReviewEditHamburger review={review} setRefreshCount={setRefreshCount!} />
           ) : null}
 


### PR DESCRIPTION
## #️⃣ 연관이슈 

- close #143 
## 📝 작업 내용

- 로그인 아닌 상태에서 user api 가져올 수있게. 서버쪽 ensureAuth 해제 및 클라이언트 user null 상태 처리.


