### PR TITLE
QA반영

### DIFF
--- a/src/components/review/EditorBox.jsx
+++ b/src/components/review/EditorBox.jsx
@@ -213,6 +213,7 @@ function EditorBox({ onContentChange, value }) {
 
         border: '1px solid',
         borderColor: 'rgb(52, 52, 52)',
+        overflowX: 'hidden',
       }}
     />
   );

--- a/src/components/review/WriteReview.tsx
+++ b/src/components/review/WriteReview.tsx
@@ -472,7 +472,13 @@ function WriteReview({ userData }) {
                 </Button>
                 <Button
                   onClick={handleSubmit}
-                  sx={{ width: '104px', height: '43px', bgcolor: 'rgb(152, 72, 255)', padding: '12px 24px 12px 24px' }}
+                  sx={{
+                    width: '104px',
+                    height: '43px',
+                    bgcolor: 'rgb(152, 72, 255)',
+                    padding: '12px 24px 12px 24px',
+                    whiteSpace: 'nowrap',
+                  }}
                 >
                   <Typography fontSize="16px" fontWeight="500">
                     작성하기

--- a/src/pages/AlbumShowPage.tsx
+++ b/src/pages/AlbumShowPage.tsx
@@ -141,7 +141,7 @@ function AlbumShowPage() {
             display: 'grid',
             gridTemplateColumns: { sm: 'repeat(3,1fr)', md: 'repeat(3,1fr)', lg: 'repeat(4, 1fr)' },
             gap: 2,
-            overflowX: { xs: 'auto' },
+            overflowX: { sm: 'auto', md: 'visible' },
             maxWidth: { xs: '100%' },
           }}
         >


### PR DESCRIPTION
## #️⃣ 연관이슈 

- close #145 

## 📝 작업 내용

- 작성하기 버튼 줄바꿈
- 앨범 상세페이지 댓글 UI잘림
- 앨범 리뷰 작성란 좌우 스크롤


## 의논할 거리
스크롤바 디자인 수정해보려고
`'::-webkit-scrollbar'`와 `msScrollbarTrackColor` 모두 사용해봤지만 
엣지, 크롬에서 적용이 되지 않았습니다.

mui자체에서 스크롤바 디자인하는 법을 더 찾지를 못해서 
`react-scrollbars-custom`를 써봐도 되지 않을까 생각중입니다.
만약 쓰게 되면 다른 스크롤바들도 디자인 통일해서 전체적으로 수정해도 괜찮지 않을까 합니다.