### PR TITLE
fix:카드 내용 간격 조정 꽉차게 + new release 기능 테스트

### DIFF
--- a/src/components/common/NewReleases.tsx
+++ b/src/components/common/NewReleases.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@mui/material';
+import { useState, useEffect } from 'react';
+import BASE_URL from '../../config';
+import { AlbumSearchResult } from '../../types/albumSearch';
+
+function NewReleases() {
+  const [newReleasesKR, setNewReleasesKR] = useState<AlbumSearchResult[]>([]);
+
+  useEffect(() => {
+    fetch(`${BASE_URL}/album/api/releases`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data);
+        setNewReleasesKR(data);
+      })
+      .catch((error) => {
+        console.error('Error fetching user data:', error);
+      });
+  }, []);
+
+  return (
+    <Box>
+      {newReleasesKR.map((release) => (
+        <Box>{release.name}</Box>
+      ))}
+    </Box>
+  );
+}
+
+export default NewReleases;

--- a/src/components/review/ReviewMain.tsx
+++ b/src/components/review/ReviewMain.tsx
@@ -71,7 +71,7 @@ function ReviewMain() {
                 artists={review.artists}
                 previewUrl={review?.previewUrl}
               />
-              <Box width="200px" mt={2}>
+              <Box mt={2}>
                 <AlbumReviewSummary review={review} />
               </Box>
             </Box>

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -10,6 +10,7 @@ import { useAuth } from '../AuthenticationContext';
 import EditProfile from '../components/common/EditProfile';
 import AlbumSearch from '../components/album/AlbumSearch/AlbumSearch';
 import Banner from '../components/common/Banner/Banner';
+// import NewReleases from '../components/common/NewReleases';
 
 function MainPage() {
   const navigate = useNavigate();
@@ -44,6 +45,7 @@ function MainPage() {
               setSelectedAlbum={setSelectedAlbum}
             />
           </Box>
+
           <Box sx={{ display: { md: 'flex', lg: 'flex' } }}>
             <Box sx={{ mt: '40px' }}>
               <ReviewMain />

--- a/src/pages/ReviewsPage.tsx
+++ b/src/pages/ReviewsPage.tsx
@@ -239,7 +239,7 @@ function ReviewsPage() {
                 </Box>
 
                 <Link to={`/album/review/${review._id}`} style={{ color: 'inherit', textDecoration: 'none' }}>
-                  <Box sx={{ width: '234px', height: '74px' }}>
+                  <Box sx={{ height: '74px' }}>
                     <Typography
                       color="white.main"
                       fontWeight={typography.weight.bold}


### PR DESCRIPTION
## #️⃣ 연관이슈 

- close #147 

## 📝 작업 내용

- 홈페이지와 리뷰 더보기 페이지의 카드 텍스트가 100%로 채워지지 않는 이유 고쳤습니다. 

- 추가로 스포티파이 api에서 new release 앨범을 불러와서 보여주면 어떨지 테스트해보려고 백엔드 로직이랑 컴포넌트는 만들어놨는데 실제 운영에 반영하기에는 좀 애매한것같아서 올려만 놓겠습니다.
